### PR TITLE
Fix Private Warp Pads

### DIFF
--- a/data/smoochypit/functions/warppad/activewarp.mcfunction
+++ b/data/smoochypit/functions/warppad/activewarp.mcfunction
@@ -29,7 +29,7 @@
 #Places the markers in the direction of other warp pads. -- warpHasSelect is when a warp has been assigned an id
 	tag @a remove wp.noIterate
 	execute as @a at @s positioned ~-5 ~-5 ~-5 if entity @e[tag=wp.locIcon,dx=10,dy=10,dz=10] run tag @s add wp.noIterate
-	execute as @a[tag=wp.using,tag=!wp.noIterate,tag=!wp.iterated,limit=1] at @s align xyz run function smoochypit:warppad/iterate/iterate
+	execute as @p[tag=wp.using,tag=!wp.noIterate,tag=!wp.iterated] at @s align xyz run function smoochypit:warppad/iterate/iterate
 
 #Unselect any selected icons
 	tag @e remove wp.selCastIcon

--- a/data/smoochypit/functions/warppad/iterate/iterate.mcfunction
+++ b/data/smoochypit/functions/warppad/iterate/iterate.mcfunction
@@ -23,9 +23,9 @@
 	function smoochypit:warppad/iterate/dimension
 
 #Remove private warp pads if their UUID doesn't match that of the player
-	execute as @e[tag=wp.pad,tag=wp.inTier1] unless score @s wp.linkedUUID matches 0 unless score @s wp.linkedUUID = @e[tag=wp.sourcePad,limit=1] wp.linkedUUID run tag @s remove wp.inTier1
-	execute as @e[tag=wp.pad,tag=wp.inTier2] unless score @s wp.linkedUUID matches 0 unless score @s wp.linkedUUID = @e[tag=wp.sourcePad,limit=1] wp.linkedUUID run tag @s remove wp.inTier2
-	execute as @e[tag=wp.pad,tag=wp.inTier3] unless score @s wp.linkedUUID matches 0 unless score @s wp.linkedUUID = @e[tag=wp.sourcePad,limit=1] wp.linkedUUID run tag @s remove wp.inTier3
+	execute as @e[tag=wp.pad,tag=wp.inTier1] unless score @s wp.linkedUUID matches 0 unless score @s wp.linkedUUID = @p[tag=wp.using] wp.linkedUUID run tag @s remove wp.inTier1
+	execute as @e[tag=wp.pad,tag=wp.inTier2] unless score @s wp.linkedUUID matches 0 unless score @s wp.linkedUUID = @p[tag=wp.using] wp.linkedUUID run tag @s remove wp.inTier2
+	execute as @e[tag=wp.pad,tag=wp.inTier3] unless score @s wp.linkedUUID matches 0 unless score @s wp.linkedUUID = @p[tag=wp.using] wp.linkedUUID run tag @s remove wp.inTier3
 
 #Remove warp pads with different frequencies
 	execute as @e[tag=wp.pad,tag=wp.inTier1] unless score @s wp.streamFreq = @e[tag=wp.sourcePad,limit=1] wp.streamFreq run tag @s remove wp.inTier1

--- a/data/smoochypit/functions/warppad/iterate/iterate.mcfunction
+++ b/data/smoochypit/functions/warppad/iterate/iterate.mcfunction
@@ -42,4 +42,4 @@
 	tag @s add wp.iterated
 
 #Again for each player who needs it fam
-	execute as @a[tag=wp.using,tag=!wp.iterated,tag=!wp.noIterate,limit=1] at @s align xyz run function smoochypit:warppad/iterate/iterate
+	execute as @p[tag=wp.using,tag=!wp.iterated,tag=!wp.noIterate] at @s align xyz run function smoochypit:warppad/iterate/iterate

--- a/data/smoochypit/functions/warppad/main.mcfunction
+++ b/data/smoochypit/functions/warppad/main.mcfunction
@@ -1,9 +1,9 @@
 #This file runs every tick -- Use with caution!
 
 #Tag player if they're using a warp pad
-	execute as @e[tag=wp.pad] at @s align xyz as @a[dx=0,dy=0,dz=0,tag=!global.ignore.pos,limit=1,scores={wp.cooldown=0}] at @s unless entity @a[tag=wp.using,distance=..4] if block ~ ~-1 ~ gold_block run tag @s add wp.using
-	execute as @e[tag=wp.pad] at @s align xyz as @a[dx=0,dy=0,dz=0,tag=!global.ignore.pos,limit=1,scores={wp.cooldown=0}] at @s unless entity @a[tag=wp.using,distance=..4] if block ~ ~-1 ~ emerald_block run tag @s add wp.using
-	execute as @e[tag=wp.pad] at @s align xyz as @a[dx=0,dy=0,dz=0,tag=!global.ignore.pos,limit=1,scores={wp.cooldown=0}] at @s unless entity @a[tag=wp.using,distance=..4] if block ~ ~-1 ~ diamond_block run tag @s add wp.using
+	execute as @e[tag=wp.pad] at @s align xyz as @p[dx=0,dy=0,dz=0,tag=!global.ignore.pos,scores={wp.cooldown=0}] at @s unless entity @a[tag=wp.using,distance=..4] if block ~ ~-1 ~ gold_block run tag @s add wp.using
+	execute as @e[tag=wp.pad] at @s align xyz as @p[dx=0,dy=0,dz=0,tag=!global.ignore.pos,scores={wp.cooldown=0}] at @s unless entity @a[tag=wp.using,distance=..4] if block ~ ~-1 ~ emerald_block run tag @s add wp.using
+	execute as @e[tag=wp.pad] at @s align xyz as @p[dx=0,dy=0,dz=0,tag=!global.ignore.pos,scores={wp.cooldown=0}] at @s unless entity @a[tag=wp.using,distance=..4] if block ~ ~-1 ~ diamond_block run tag @s add wp.using
 	execute as @a[tag=wp.using] at @s align xyz unless entity @e[tag=wp.pad,dx=0,dy=0,dz=0] run tag @s remove wp.using
 
 #Run if a warp pad has an item on it

--- a/data/smoochypit/functions/warppad/warping/launch.mcfunction
+++ b/data/smoochypit/functions/warppad/warping/launch.mcfunction
@@ -4,6 +4,6 @@
 	tag @e[tag=wp.pad,limit=1,sort=nearest] add wp.wlIterated
 
 #warp or retry - note: "wp.hasSelect" is a requirement to run, and may break in complicated ways without.
-	execute if score @e[tag=wp.selCastIcon,limit=1,sort=nearest] wp.tempID = @e[tag=wp.pad,limit=1,sort=nearest,tag=wp.hasSelect] wp.tempID as @a[tag=wp.pilot,limit=1,sort=nearest] at @s at @e[tag=wp.pad,distance=..5] run tag @e[tag=wp.passenger,distance=..5] add wp.activePass
+	execute if score @e[tag=wp.selCastIcon,limit=1,sort=nearest] wp.tempID = @e[tag=wp.pad,limit=1,sort=nearest,tag=wp.hasSelect] wp.tempID as @p[tag=wp.pilot] at @s at @e[tag=wp.pad,distance=..5] run tag @e[tag=wp.passenger,distance=..5] add wp.activePass
 	execute if score @e[tag=wp.selCastIcon,limit=1,sort=nearest] wp.tempID = @e[tag=wp.pad,limit=1,sort=nearest,tag=wp.hasSelect] wp.tempID at @e[tag=wp.pad,limit=1,sort=nearest,tag=wp.hasSelect] run function smoochypit:warppad/warping/players
 	execute if entity @e[tag=wp.pad,tag=!wp.wlIterated,limit=1,sort=nearest,tag=wp.hasSelect] at @e[tag=wp.pad,tag=!wp.wlIterated,limit=1,sort=nearest,tag=wp.hasSelect] run function smoochypit:warppad/warping/launch

--- a/data/smoochypit/functions/warppad/warping/setup.mcfunction
+++ b/data/smoochypit/functions/warppad/warping/setup.mcfunction
@@ -4,9 +4,9 @@
 	tag @e remove wp.pilot
 	tag @e remove wp.wlIterated
 	tag @e remove wp.activePass
-	tag @a[tag=wp.using,tag=!wp.wsIterated,limit=1,sort=nearest,scores={wp.sneakClick=1..}] add wp.pilot
-	execute as @a[tag=wp.pilot,limit=1,sort=nearest] at @s at @e[tag=wp.pad,limit=1,sort=nearest] if entity @e[tag=wp.selCastIcon,distance=..10] run function smoochypit:warppad/warping/launch
-	tag @a[tag=wp.pilot,limit=1,sort=nearest] add wp.wsIterated
+	tag @p[tag=wp.using,tag=!wp.wsIterated,scores={wp.sneakClick=1..}] add wp.pilot
+	execute as @p[tag=wp.pilot] at @s at @e[tag=wp.pad] if entity @e[tag=wp.selCastIcon,distance=..10] run function smoochypit:warppad/warping/launch
+	tag @a[tag=wp.pilot] add wp.wsIterated
 
 #call it again as the next player if another player is found
-	execute if entity @a[tag=wp.using,tag=!wp.wsIterated,scores={wp.sneakClick=1..}] as @a[tag=wp.using,tag=!wp.wsIterated,limit=1,sort=nearest,scores={wp.sneakClick=1..}] at @s at @e[tag=wp.pad,limit=1,sort=nearest] if entity @e[tag=wp.selCastIcon,distance=..10] run function smoochypit:warppad/warping/setup
+	execute as @p[tag=wp.using,tag=!wp.wsIterated,scores={wp.sneakClick=1..}] at @s at @e[tag=wp.pad,limit=1,sort=nearest] if entity @e[tag=wp.selCastIcon,distance=..10] run function smoochypit:warppad/warping/setup


### PR DESCRIPTION
Fixes private warp pads by comparing the player to their linked UUID rather than the current warp pad. (Private warp pads are now usable again!)

Also some small changes to reduce redundancy.